### PR TITLE
ocaml-admd.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-admd/ocaml-admd.0.1/descr
+++ b/packages/ocaml-admd/ocaml-admd.0.1/descr
@@ -1,0 +1,3 @@
+A pure OCaml library to read and write Admd XML files.
+
+This is a pure OCaml library to read and write Admd XML files.

--- a/packages/ocaml-admd/ocaml-admd.0.1/opam
+++ b/packages/ocaml-admd/ocaml-admd.0.1/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-admd"
+bug-reports: "https://github.com/johanmazel/ocaml-admd/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-admd.git"
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "admd"]

--- a/packages/ocaml-admd/ocaml-admd.0.1/url
+++ b/packages/ocaml-admd/ocaml-admd.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-admd/archive/0.1.tar.gz"
+checksum: "d3484325e717d433655b35a79fec63cd"


### PR DESCRIPTION
A pure OCaml library to read and write Admd XML files.

This is a pure OCaml library to read and write Admd XML files.

---
- Homepage: https://github.com/johanmazel/ocaml-admd
- Source repo: https://github.com/johanmazel/ocaml-admd.git
- Bug tracker: https://github.com/johanmazel/ocaml-admd/issues

---

Pull-request generated by opam-publish v0.3.1
