### PR TITLE
ocaml-admd.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-admd/ocaml-admd.0.1/opam
+++ b/packages/ocaml-admd/ocaml-admd.0.1/opam
@@ -6,6 +6,7 @@ bug-reports: "https://github.com/johanmazel/ocaml-admd/issues"
 license: "GPL3"
 dev-repo: "https://github.com/johanmazel/ocaml-admd.git"
 build: [
+  ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure"]
   ["ocaml" "setup.ml" "-build"]
 ]

--- a/packages/ocaml-admd/ocaml-admd.0.1/url
+++ b/packages/ocaml-admd/ocaml-admd.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-admd/archive/0.1.tar.gz"
-checksum: "cce9493861743fd18c9f00739c77b063"
+checksum: "5e1cbc2a21a88a763e7d6396614d36c5"


### PR DESCRIPTION
A pure OCaml library to read and write Admd XML files.

This is a pure OCaml library to read and write Admd XML files.

---
- Homepage: https://github.com/johanmazel/ocaml-admd
- Source repo: https://github.com/johanmazel/ocaml-admd.git
- Bug tracker: https://github.com/johanmazel/ocaml-admd/issues

---

Pull-request generated by opam-publish v0.3.1
