### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/descr
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/descr
@@ -1,0 +1,3 @@
+Network traffic analysis libraries.
+
+Network traffic analysis libraries.

--- a/packages/ocaml-netralys/ocaml-netralys.0.1/opam
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-netralys"
+bug-reports: "https://github.com/johanmazel/ocaml-netralys/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-netralys.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "admd"]

--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
+checksum: "ac28e53f3ba88bc7a4a437b7ef99d160"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
