### PR TITLE
ocaml-jl.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-jl/ocaml-jl.0.1/opam
+++ b/packages/ocaml-jl/ocaml-jl.0.1/opam
@@ -1,10 +1,10 @@
 opam-version: "1.2"
 maintainer: "johan.mazel@gmail.com"
 authors: "Johan Mazel"
-homepage: "https://github.com/johanmazel/ocaml-admd"
-bug-reports: "https://github.com/johanmazel/ocaml-admd/issues"
+homepage: "https://github.com/johanmazel/ocaml-jl"
+bug-reports: "https://github.com/johanmazel/ocaml-jl/issues"
 license: "GPL3"
-dev-repo: "https://github.com/johanmazel/ocaml-admd.git"
+dev-repo: "https://github.com/johanmazel/ocaml-jl.git"
 build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure"]

--- a/packages/ocaml-jl/ocaml-jl.0.1/url
+++ b/packages/ocaml-jl/ocaml-jl.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-jl/archive/0.1.tar.gz"
-checksum: "728ba3c6b0ac000b3209f01a68346b48"
+checksum: "2529bc5aad5a883593a0d5acbbd9f913"


### PR DESCRIPTION
Simple description.

Long description.

---
- Homepage: https://github.com/johanmazel/ocaml-jl
- Source repo: https://github.com/johanmazel/ocaml-jl.git
- Bug tracker: https://github.com/johanmazel/ocaml-jl/issues

---

Pull-request generated by opam-publish v0.3.1
