### PR TITLE
ocaml-jl.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-jl/ocaml-jl.0.1/url
+++ b/packages/ocaml-jl/ocaml-jl.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-jl/archive/0.1.tar.gz"
-checksum: "5b5659bf638e0005159edbc33d86f979"
+checksum: "b91df673b86ff5b3d9751d164a6f8bcb"


### PR DESCRIPTION
Simple description.

Long description.

---
- Homepage: https://github.com/johanmazel/ocaml-jl
- Source repo: https://github.com/johanmazel/ocaml-jl.git
- Bug tracker: https://github.com/johanmazel/ocaml-jl/issues

---

Pull-request generated by opam-publish v0.3.1
