### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/opam
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/opam
@@ -11,4 +11,11 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-remove: ["ocamlfind" "remove" "admd"]
+remove: [
+  ["ocamlfind" "remove" "netralys_trace_parsing"]
+  ["ocamlfind" "remove" "netralys_packet_data"]
+  ["ocamlfind" "remove" "netralys_flow"]
+  ["ocamlfind" "remove" "netralys_metrics"]
+  ["ocamlfind" "remove" "netralys_attribute_value"]
+  ["ocamlfind" "remove" "netralys_ipaddr_container"]
+]

--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "50ef8159f7a142f490b2297b57be22bb"
+checksum: "1b91c863eae127a27afcc20911bcc088"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
