### PR TITLE
ocaml-nac_taxonomy.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/descr
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/descr
@@ -1,0 +1,3 @@
+Library for network anomaly classification taxonomy.
+
+Library for network anomaly classification taxonomy.

--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/opam
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-nac_taxonomy"
+bug-reports: "https://github.com/johanmazel/ocaml-nac_taxonomy/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-nac_taxonomy.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "nac_taxonomy"]

--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/url
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-nac_taxonomy/archive/0.1.tar.gz"
+checksum: "b340092a80e4bf48adbc98e6cb6c7088"


### PR DESCRIPTION
Library for network anomaly classification taxonomy.

Library for network anomaly classification taxonomy.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_taxonomy
- Source repo: https://github.com/johanmazel/ocaml-nac_taxonomy.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_taxonomy/issues

---

Pull-request generated by opam-publish v0.3.1
