### PR TITLE
ocaml-nac_lib.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/descr
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/descr
@@ -1,0 +1,3 @@
+Library for network anomaly classification.
+
+Library for network anomaly classification.

--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/opam
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-nac_lib"
+bug-reports: "https://github.com/johanmazel/ocaml-nac_lib/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-nac_lib.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "nac_lib"]

--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-nac_lib/archive/0.1.tar.gz"
+checksum: "9dbb2b21703c5f9bc97f72e1271fb67b"


### PR DESCRIPTION
Library for network anomaly classification.

Library for network anomaly classification.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_lib
- Source repo: https://github.com/johanmazel/ocaml-nac_lib.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_lib/issues

---

Pull-request generated by opam-publish v0.3.1
