### PR TITLE
ocaml-nac_taxonomy.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/url
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-nac_taxonomy/archive/0.1.tar.gz"
-checksum: "f55aad6f0a3d32212dab59c8052adae0"
+checksum: "adac936a4a9bc4b158685120f77e6e0d"


### PR DESCRIPTION
Library for network anomaly classification taxonomy.

Library for network anomaly classification taxonomy.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_taxonomy
- Source repo: https://github.com/johanmazel/ocaml-nac_taxonomy.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_taxonomy/issues

---

Pull-request generated by opam-publish v0.3.1
