### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/opam
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/opam
@@ -19,3 +19,14 @@ remove: [
   ["ocamlfind" "remove" "netralys_attribute_value"]
   ["ocamlfind" "remove" "netralys_ipaddr_container"]
 ]
+depends: [
+  "cstruct"
+  "pcap-format"
+  "bitstring"
+  "ipaddr"
+  "uint"
+  "gsl"
+  "jl"
+  "robinet_parsing"
+  "admd"
+]

--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "1b91c863eae127a27afcc20911bcc088"
+checksum: "00e956e7441706531408e9d3e9db2de1"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
