### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/opam
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/opam
@@ -26,7 +26,7 @@ depends: [
   "ipaddr"
   "uint"
   "gsl"
-  "jl"
-  "robinet_parsing"
+  "ocaml-jl"
+  "ocaml-robinet_parsing"
   "ocaml-admd"
 ]

--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "f4fba8a638a3deaad6008def72f8be75"
+checksum: "cc6368dda54c9d8359f7dd28d625e0b4"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
