### PR TITLE
ocaml-nac_lib.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/opam
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/opam
@@ -12,10 +12,4 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "nac_lib"]
-depends: [
-  "batteries"
-  "jl"
-  "netralys_metrics"
-  "netralys_ipaddr_container"
-  "netralys_attribute_value"
-]
+depends: ["batteries" "ocaml-jl" "ocaml-netralys"]

--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-nac_lib/archive/0.1.tar.gz"
-checksum: "58be5f6ca4108ea871360f0db50c3aa3"
+checksum: "3ddb6105d4e99943b002d40bf88ff9de"


### PR DESCRIPTION
Library for network anomaly classification.

Library for network anomaly classification.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_lib
- Source repo: https://github.com/johanmazel/ocaml-nac_lib.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_lib/issues

---

Pull-request generated by opam-publish v0.3.1
