### PR TITLE
ocaml-jl.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-jl/ocaml-jl.0.1/url
+++ b/packages/ocaml-jl/ocaml-jl.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-jl/archive/0.1.tar.gz"
-checksum: "e6b7ad87b9697f45bca6df8b6ffbae8d"
+checksum: "182235e950989cb982b2f2cd2ef6040b"


### PR DESCRIPTION
Simple description.

Long description.

---
- Homepage: https://github.com/johanmazel/ocaml-jl
- Source repo: https://github.com/johanmazel/ocaml-jl.git
- Bug tracker: https://github.com/johanmazel/ocaml-jl/issues

---

Pull-request generated by opam-publish v0.3.1
