### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/opam
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/opam
@@ -20,6 +20,8 @@ remove: [
   ["ocamlfind" "remove" "netralys_ipaddr_container"]
 ]
 depends: [
+  "ocamlfind"
+  "oasis"
   "cstruct"
   "pcap-format"
   "bitstring"

--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "cc6368dda54c9d8359f7dd28d625e0b4"
+checksum: "f1bdb045f6c546313cb741b4ca510dce"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
