### PR TITLE
ocaml-nac_taxonomy.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/opam
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/opam
@@ -12,4 +12,4 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "nac_taxonomy"]
-depends: ["ocaml-jl" "ocaml-netralys"]
+depends: ["ocamlfind" "oasis" "ocaml-jl" "ocaml-netralys"]

--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/url
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-nac_taxonomy/archive/0.1.tar.gz"
-checksum: "0691c4093aad51157cb6682e8547b199"
+checksum: "fa3fe22f79e73cf745445582a7a0c885"


### PR DESCRIPTION
Library for network anomaly classification taxonomy.

Library for network anomaly classification taxonomy.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_taxonomy
- Source repo: https://github.com/johanmazel/ocaml-nac_taxonomy.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_taxonomy/issues

---

Pull-request generated by opam-publish v0.3.1
