### PR TITLE
ocaml-nac_lib.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/opam
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/opam
@@ -12,4 +12,11 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "nac_lib"]
-depends: ["batteries" "ocaml-jl" "ocaml-netralys" "ocaml-nac_taxonomy"]
+depends: [
+  "ocamlfind"
+  "oasis"
+  "batteries"
+  "ocaml-jl"
+  "ocaml-netralys"
+  "ocaml-nac_taxonomy"
+]

--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-nac_lib/archive/0.1.tar.gz"
-checksum: "02f894c17bd316f86ec398493e3bcac7"
+checksum: "764a0b7f46235e4dd339fb3aaf9a615f"


### PR DESCRIPTION
Library for network anomaly classification.

Library for network anomaly classification.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_lib
- Source repo: https://github.com/johanmazel/ocaml-nac_lib.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_lib/issues

---

Pull-request generated by opam-publish v0.3.1
