### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/opam
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/opam
@@ -28,7 +28,6 @@ depends: [
   "ipaddr"
   "uint"
   "gsl"
-  "menhir"
   "ocaml-jl"
   "ocaml-robinet_parsing"
   "ocaml-admd"

--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "c3ee019adb823fa9a3e5d2952a3aa179"
+checksum: "1ffffbd3760d2aae3d61a72adeea89db"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
