### PR TITLE
ocaml-admd.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-admd/ocaml-admd.0.1/url
+++ b/packages/ocaml-admd/ocaml-admd.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-admd/archive/0.1.tar.gz"
-checksum: "65a605cc2c8c2246e044069af5893106"
+checksum: "f02f8562b26ed5dd794815f49def08ab"


### PR DESCRIPTION
A pure OCaml library to read and write Admd XML files.

This is a pure OCaml library to read and write Admd XML files.

---
- Homepage: https://github.com/johanmazel/ocaml-admd
- Source repo: https://github.com/johanmazel/ocaml-admd.git
- Bug tracker: https://github.com/johanmazel/ocaml-admd/issues

---

Pull-request generated by opam-publish v0.3.1
