### PR TITLE
ocaml-admd.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-admd/ocaml-admd.0.1/url
+++ b/packages/ocaml-admd/ocaml-admd.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-admd/archive/0.1.tar.gz"
-checksum: "88288c6615887c1dadf7a76ab91441d2"
+checksum: "67b4be278bae794201630749b508047b"


### PR DESCRIPTION
A pure OCaml library to read and write Admd XML files.

This is a pure OCaml library to read and write Admd XML files.

---
- Homepage: https://github.com/johanmazel/ocaml-admd
- Source repo: https://github.com/johanmazel/ocaml-admd.git
- Bug tracker: https://github.com/johanmazel/ocaml-admd/issues

---

Pull-request generated by opam-publish v0.3.1
