### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "ee7c67ca1bf632d19ee894af60faf25c"
+checksum: "0c1305ec4bb340eb827c25c459e76f63"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
