### PR TITLE
ocaml-nac_lib.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-nac_lib/archive/0.1.tar.gz"
-checksum: "d805d828af78fb90266dbba282bae5d7"
+checksum: "59e7ca3e4406ae9b93570d122daa7fb2"


### PR DESCRIPTION
Library for network anomaly classification.

Library for network anomaly classification.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_lib
- Source repo: https://github.com/johanmazel/ocaml-nac_lib.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_lib/issues

---

Pull-request generated by opam-publish v0.3.1
