### PR TITLE
ocaml-nac_lib.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-nac_lib/archive/0.1.tar.gz"
-checksum: "d4890fcb066cf4df488325efb50338a9"
+checksum: "ca14a1e3ae4aabc0b61a7a7339ecfd2f"


### PR DESCRIPTION
Library for network anomaly classification.

Library for network anomaly classification.

---
- Homepage: https://github.com/johanmazel/ocaml-nac_lib
- Source repo: https://github.com/johanmazel/ocaml-nac_lib.git
- Bug tracker: https://github.com/johanmazel/ocaml-nac_lib/issues

---

Pull-request generated by opam-publish v0.3.1
