### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "497ffbc25735e03107acb1d07e4c63b7"
+checksum: "8674d32e21f55d65e6dc144bd6d44c7d"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
