### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "59d3ff77316f3b4ce9b030d5fe9799ab"
+checksum: "ff8dbd899d45ce79d8f705ed1c5157b4"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
