### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "ecb47c1ea807c29a0b3979de9e81019c"
+checksum: "82e8c8cf7993f9701fc85f5b72bf7a18"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.1
