### PR TITLE
ocaml-jl.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-jl/ocaml-jl.0.1/url
+++ b/packages/ocaml-jl/ocaml-jl.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-jl/archive/0.1.tar.gz"
-checksum: "ecc80e4ff26cc0010e8e3050bf83e619"
+checksum: "980f562e9cb5bafda942b57a22b147e8"


### PR DESCRIPTION
Simple description.

Long description.

---
- Homepage: https://github.com/johanmazel/ocaml-jl
- Source repo: https://github.com/johanmazel/ocaml-jl.git
- Bug tracker: https://github.com/johanmazel/ocaml-jl/issues

---

Pull-request generated by opam-publish v0.3.1
