### PR TITLE
ocaml-jl.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-jl/ocaml-jl.0.1/url
+++ b/packages/ocaml-jl/ocaml-jl.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-jl/archive/0.1.tar.gz"
-checksum: "2ebb98e202a7d81e7010cfd680a8032e"
+checksum: "14696712cf6cb17b7af62181e79558a2"


### PR DESCRIPTION
Simple description.

Long description.

---
- Homepage: https://github.com/johanmazel/ocaml-jl
- Source repo: https://github.com/johanmazel/ocaml-jl.git
- Bug tracker: https://github.com/johanmazel/ocaml-jl/issues

---

Pull-request generated by opam-publish v0.3.1
