### PR TITLE
ocaml-jl.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-jl/ocaml-jl.0.1/url
+++ b/packages/ocaml-jl/ocaml-jl.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-jl/archive/0.1.tar.gz"
-checksum: "14696712cf6cb17b7af62181e79558a2"
+checksum: "03a3be892264372bdd1261342edf2946"


### PR DESCRIPTION
Simple description.

Long description.

---
- Homepage: https://github.com/johanmazel/ocaml-jl
- Source repo: https://github.com/johanmazel/ocaml-jl.git
- Bug tracker: https://github.com/johanmazel/ocaml-jl/issues

---

Pull-request generated by opam-publish v0.3.1
