### PR TITLE
ocaml-netralys.0.1 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.1/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.1.tar.gz"
-checksum: "8e3a646bf71404a053cb498067251c7b"
+checksum: "ee55d3a99d76fa165911767035e15882"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.

---
- Homepage: https://github.com/johanmazel/ocaml-netralys
- Source repo: https://github.com/johanmazel/ocaml-netralys.git
- Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.2
