### PR TITLE
ocaml-admd.0.2 - via opam-publish

### DIFF
--- a/packages/ocaml-admd/ocaml-admd.0.2/descr
+++ b/packages/ocaml-admd/ocaml-admd.0.2/descr
@@ -1,0 +1,3 @@
+A pure OCaml library to read and write Admd XML files.
+
+This is a pure OCaml library to read and write Admd XML files.

--- a/packages/ocaml-admd/ocaml-admd.0.2/opam
+++ b/packages/ocaml-admd/ocaml-admd.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-admd"
+bug-reports: "https://github.com/johanmazel/ocaml-admd/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-admd.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "admd"]
+depends: [
+  "oasis"
+  "ocamlfind"
+  "batteries"
+  "core"
+  "xmlm"
+  "xml-light"
+  "ipaddr"
+  "ppx_compare"
+  "ppx_sexp_conv"
+  "ppx_bin_prot"
+  "ocaml-jl"
+]

--- a/packages/ocaml-admd/ocaml-admd.0.2/url
+++ b/packages/ocaml-admd/ocaml-admd.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-admd/archive/0.2.tar.gz"
+checksum: "723fc63c80a724001c53bd77155895eb"


### PR DESCRIPTION
A pure OCaml library to read and write Admd XML files.

This is a pure OCaml library to read and write Admd XML files.


---
* Homepage: https://github.com/johanmazel/ocaml-admd
* Source repo: https://github.com/johanmazel/ocaml-admd.git
* Bug tracker: https://github.com/johanmazel/ocaml-admd/issues

---

Pull-request generated by opam-publish v0.3.3