### PR TITLE
ocaml-netralys.0.2 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.2/descr
+++ b/packages/ocaml-netralys/ocaml-netralys.0.2/descr
@@ -1,0 +1,3 @@
+Network traffic analysis libraries.
+
+Network traffic analysis libraries.

--- a/packages/ocaml-netralys/ocaml-netralys.0.2/opam
+++ b/packages/ocaml-netralys/ocaml-netralys.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-netralys"
+bug-reports: "https://github.com/johanmazel/ocaml-netralys/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-netralys.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: [
+  ["ocamlfind" "remove" "netralys_trace_parsing"]
+  ["ocamlfind" "remove" "netralys_packet_data"]
+  ["ocamlfind" "remove" "netralys_flow"]
+  ["ocamlfind" "remove" "netralys_metrics"]
+  ["ocamlfind" "remove" "netralys_attribute_value"]
+  ["ocamlfind" "remove" "netralys_ipaddr_container"]
+]
+depends: [
+  "oasis"
+  "ocamlfind"
+  "cstruct"
+  "pcap-format"
+  "bitstring"
+  "ipaddr"
+  "uint"
+  "gsl"
+  "ppx_compare"
+  "ppx_sexp_conv"
+  "ppx_bin_prot"
+  "ocaml-jl"
+  "ocaml-robinet_parsing"
+  "ocaml-admd"
+]

--- a/packages/ocaml-netralys/ocaml-netralys.0.2/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-netralys/archive/0.2.tar.gz"
+checksum: "450818e4fbc4ceaf939aa9205931bcd4"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.


---
* Homepage: https://github.com/johanmazel/ocaml-netralys
* Source repo: https://github.com/johanmazel/ocaml-netralys.git
* Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.3