### PR TITLE
ocaml-nac_taxonomy.0.2 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.2/descr
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.2/descr
@@ -1,0 +1,3 @@
+Library for network anomaly classification taxonomy.
+
+Library for network anomaly classification taxonomy.

--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.2/opam
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-nac_taxonomy"
+bug-reports: "https://github.com/johanmazel/ocaml-nac_taxonomy/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-nac_taxonomy.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "nac_taxonomy"]
+depends: [
+  "oasis"
+  "ocamlfind"
+  "menhir"
+  "ocaml-jl"
+  "ocaml-netralys"
+  "ppx_compare"
+  "ppx_sexp_conv"
+  "ppx_bin_prot"
+]

--- a/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.2/url
+++ b/packages/ocaml-nac_taxonomy/ocaml-nac_taxonomy.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-nac_taxonomy/archive/0.2.tar.gz"
+checksum: "988875c66349996711e7bafa65456ec6"


### PR DESCRIPTION
Library for network anomaly classification taxonomy.

Library for network anomaly classification taxonomy.


---
* Homepage: https://github.com/johanmazel/ocaml-nac_taxonomy
* Source repo: https://github.com/johanmazel/ocaml-nac_taxonomy.git
* Bug tracker: https://github.com/johanmazel/ocaml-nac_taxonomy/issues

---

Pull-request generated by opam-publish v0.3.3