### PR TITLE
ocaml-nac_lib.0.2 - via opam-publish

### DIFF
--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.2/descr
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.2/descr
@@ -1,0 +1,3 @@
+Library for network anomaly classification.
+
+Library for network anomaly classification.

--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.2/opam
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.2/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "johan.mazel@gmail.com"
+authors: "Johan Mazel"
+homepage: "https://github.com/johanmazel/ocaml-nac_lib"
+bug-reports: "https://github.com/johanmazel/ocaml-nac_lib/issues"
+license: "GPL3"
+dev-repo: "https://github.com/johanmazel/ocaml-nac_lib.git"
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "nac_lib"]
+depends: [
+  "oasis"
+  "ocamlfind"
+  "batteries"
+  "ocaml-jl"
+  "ocaml-netralys"
+  "ocaml-nac_taxonomy"
+  "ppx_compare"
+  "ppx_sexp_conv"
+  "ppx_bin_prot"
+]

--- a/packages/ocaml-nac_lib/ocaml-nac_lib.0.2/url
+++ b/packages/ocaml-nac_lib/ocaml-nac_lib.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/johanmazel/ocaml-nac_lib/archive/0.2.tar.gz"
+checksum: "1783eef71140d18d9ab79dfd112108c1"


### PR DESCRIPTION
Library for network anomaly classification.

Library for network anomaly classification.


---
* Homepage: https://github.com/johanmazel/ocaml-nac_lib
* Source repo: https://github.com/johanmazel/ocaml-nac_lib.git
* Bug tracker: https://github.com/johanmazel/ocaml-nac_lib/issues

---

Pull-request generated by opam-publish v0.3.3