### PR TITLE
ocaml-netralys.0.2 - via opam-publish

### DIFF
--- a/packages/ocaml-netralys/ocaml-netralys.0.2/url
+++ b/packages/ocaml-netralys/ocaml-netralys.0.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/johanmazel/ocaml-netralys/archive/0.2.tar.gz"
-checksum: "a3ce625663e60edf44c405ef6ef0512c"
+checksum: "41f3870cd05645eceebceb737de68df0"


### PR DESCRIPTION
Network traffic analysis libraries.

Network traffic analysis libraries.


---
* Homepage: https://github.com/johanmazel/ocaml-netralys
* Source repo: https://github.com/johanmazel/ocaml-netralys.git
* Bug tracker: https://github.com/johanmazel/ocaml-netralys/issues

---

Pull-request generated by opam-publish v0.3.3